### PR TITLE
initialize MessageBus before ProxyObject to prevent race condition in error handling.

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -190,12 +190,10 @@ class MessageBus extends EventEmitter {
    * @returns {Promise} - a Promise that resolves with the `ProxyObject`.
    */
   async getProxyObject (name, path, xml) {
-    const obj = new ProxyObject(this, name, path);
-
-    const objInitPromise = obj._init(xml);
-
     await this._initHighLevelClient();
 
+    const obj = new ProxyObject(this, name, path);
+    const objInitPromise = obj._init(xml);
     return objInitPromise;
   }
 


### PR DESCRIPTION
So, I'm not 100% sure on why this fixes things. In theory the await/new Promise chain all seems to be intact, but possibly it has to do with https://github.com/JellyBrick/node-dbus-next/blob/master/lib/bus.js#L493 and/or having a two handlers bound when only 1 is expected to be. But it does fix it.

To test this, you can call `bus.getProxyObject()` in a loop against a service that does not existing/is not online and wrap the call in a try/catch that should catch the errors. Before the patch, you'll catch a few of the errors then eventually it'll crash, after the patch I've tested 200k iterations without any uncaught errors.